### PR TITLE
Fix declaration of env parameter in fromjstring/tojstring functions.

### DIFF
--- a/src/native/org_gnu_readline_Readline.c
+++ b/src/native/org_gnu_readline_Readline.c
@@ -307,8 +307,8 @@ static size_t bufLength = 0;
 
 static char*  word_break_buffer = NULL;
 
-static char* fromjstring(const JNIEnv *env, jstring value);
-static jstring tojstring(const JNIEnv *env, const char* value);
+static char* fromjstring(JNIEnv const *env, jstring value);
+static jstring tojstring(JNIEnv const *env, const char* value);
 
 static int   allocBuffer(size_t n);
 
@@ -776,7 +776,7 @@ JNIEXPORT jstring JNICALL
 /* Convert jstring to c-string                                                */
 /* -------------------------------------------------------------------------- */
 
-char* fromjstring(const JNIEnv *env, jstring value) {
+char* fromjstring(JNIEnv const *env, jstring value) {
   const jclass jstringClass = (*env)->GetObjectClass(env, value);
   const jmethodID getBytesMethodId = (*env)->GetMethodID(env, jstringClass, "getBytes", "()[B");
 
@@ -822,7 +822,7 @@ char* fromjstring(const JNIEnv *env, jstring value) {
 /* Convert c-string to j-string                                               */
 /* -------------------------------------------------------------------------- */
 
-jstring tojstring(const JNIEnv *env, const char* value) {
+jstring tojstring(JNIEnv const *env, const char* value) {
   const jclass jstringClass = (*env)->FindClass(env,"java/lang/String");
   const jmethodID constructorMethodId = (*env)->GetMethodID(env, jstringClass, "<init>", "([B)V");
 


### PR DESCRIPTION
These should take a pointer to a JNIEnv. These were introduced in b178aa0 to
replace:

```c
static char* utf2ucs(const char *utf8, char *ucs, size_t n);
static char* ucs2utf(const char *ucs, char *utf8, size_t n);
```

They were added as:

```c
static char* fromjstring(const JNIEnv *env, jstring value);
static jstring tojstring(const JNIEnv *env, const char* value);
```

In this case however, we actually just wanted to declare these as a
constant pointer not a pointer to a constant.

Newer gcc versions complain with:

```
org_gnu_readline_Readline.c: In function ‘fromjstring’:
org_gnu_readline_Readline.c:780:54: warning: passing argument 1 of ‘((const struct JNINativeInterface_ *)*env)->GetObjectClass’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  780 |   const jclass jstringClass = (*env)->GetObjectClass(env, value);
      |                                                      ^~~
org_gnu_readline_Readline.c:780:54: note: expected ‘const struct JNINativeInterface_ **’ but argument is of type ‘const struct JNINativeInterface_ * const*’
org_gnu_readline_Readline.c:781:58: warning: passing argument 1 of ‘((const struct JNINativeInterface_ *)*env)->GetMethodID’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  781 |   const jmethodID getBytesMethodId = (*env)->GetMethodID(env, jstringClass, "getBytes", "()[B");
      |                                                          ^~~
org_gnu_readline_Readline.c:781:58: note: expected ‘const struct JNINativeInterface_ **’ but argument is of type ‘const struct JNINativeInterface_ * const*’
org_gnu_readline_Readline.c:783:74: warning: passing argument 1 of ‘((const struct JNINativeInterface_ *)*env)->CallObjectMethod’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  783 |   const jbyteArray jstringJBytes = (jbyteArray) (*env)->CallObjectMethod(env, value, getBytesMethodId);
      |                                                                          ^~~
```

Newer clang versions complain with:

```
org_gnu_readline_Readline.c:780:54: warning: passing 'const JNIEnv *' (aka 'const struct JNINativeInterface_ *const *') to parameter of type 'JNIEnv *' (aka 'const struct JNINativeInterface_ **') discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
  780 |   const jclass jstringClass = (*env)->GetObjectClass(env, value);
      |                                                      ^~~
org_gnu_readline_Readline.c:781:58: warning: passing 'const JNIEnv *' (aka 'const struct JNINativeInterface_ *const *') to parameter of type 'JNIEnv *' (aka 'const struct JNINativeInterface_ **') discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
  781 |   const jmethodID getBytesMethodId = (*env)->GetMethodID(env, jstringClass, "getBytes", "()[B");
      |                                                          ^~~
org_gnu_readline_Readline.c:783:74: warning: passing 'const JNIEnv *' (aka 'const struct JNINativeInterface_ *const *') to parameter of type 'JNIEnv *' (aka 'const struct JNINativeInterface_ **') discards qualifiers [-Wincompatible-pointer-types-discards-qualifiers]
  783 |   const jbyteArray jstringJBytes = (jbyteArray) (*env)->CallObjectMethod(env, value, getBytesMethodId);
      |                                                                          ^~~
```

Related to #41
