### PR TITLE
Handle `rl_readline_state` being a long int from readline 7.0.

### DIFF
--- a/src/native/org_gnu_readline_Readline.c
+++ b/src/native/org_gnu_readline_Readline.c
@@ -95,7 +95,12 @@ extern char* gl_buf;
 static int* globalIntegerInternals[] = {
   &rl_readline_version,
   &rl_gnu_readline_p,
+#if (RL_READLINE_VERSION >= 0x0700)
+  /* in readline 7.0, this field was changed to a long int. It's still holds a 32bit value so we'll cast. */
+  (int *) &rl_readline_state,
+#else
   &rl_readline_state,
+#endif
   &rl_editing_mode,
   &rl_insert_mode,
   &rl_point,


### PR DESCRIPTION
https://cgit.git.savannah.gnu.org/cgit/readline.git/commit/readline.h?id=d49a9082c0e15bba8cd3d8cc0a994409cf823cac

I've opted to handle this in the same way that Term::ReadLine::Gnu
handles it since both libraries were tracking values as arrays of ints.

https://github.com/hirooih/perl-trg/blob/9c89044bca3437a4f5520357cee1d5971db9877b/Gnu.xs#L545-L553

Closes #45