### PR TITLE
Install libreadline-dev on GHA runners for testing with ubuntu 24.04.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install dependencies
       run: |
          sudo apt-get update -qq
-         sudo apt-get install -qq bats libedit-dev libedit2
+         sudo apt-get install -qq bats libedit-dev libedit2 libreadline-dev
     - name: Build
       run: |
          make clean bats T_LIBS="JavaEditline JavaReadline JavaGetline" CC=${{ matrix.cc }}


### PR DESCRIPTION
This was previously included in the base image, but now needs
to be manually installed.